### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
 ]
 
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+
 [build-system]
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
to fix error 
[tool.bench.frappe-dependencies]
frappe = ">=16.0.0,<17.0.0" is added
Error:
Could not find a compatible Frappe version in pyproject.toml for app 'ls_shop'. Please ensure '[tool.bench.frappe-dependencies]' is defined. Click here for more details.