### PR TITLE
fix(commera): use an 8-digit HSN code for the demo catalogue

### DIFF
--- a/commera/install_fashion_demo_data.py
+++ b/commera/install_fashion_demo_data.py
@@ -9,8 +9,9 @@ from commera.install_demo_data import (
 
 IMAGE_ROOT = "/assets/commera/themes/summer_theme/images"
 
-# Apparel, knitted: the closest single heading for a demo catalogue that is all garments.
-DEMO_HSN_CODE = "6109"
+# Knitted cotton t-shirts. Eight digits, because GST Settings.min_hsn_digits defaults to 6 and
+# only 4/6/8 are accepted - an 8-digit code stays valid whatever a site raises that floor to.
+DEMO_HSN_CODE = "61091000"
 
 CAR_PART_TEMPLATES = ("BRAKE-PADS", "AIR-FILTER", "FLOOR-MATS")
 CAR_PART_CATEGORIES = ("Engine Parts", "Brake System", "Interior Accessories")


### PR DESCRIPTION
## Why

`9103dd7` taught the demo seeder to stamp `gst_hsn_code` so `install_summer_demo` stops dying on india_compliance's mandatory check. The code it picked, `6109`, is four digits — and that is rejected on a **default** india_compliance site.

`GST Settings.min_hsn_digits` defaults to **6**, and `get_hsn_settings()` narrows the accepted set to lengths at or above it:

```python
valid_hsn_length = tuple(length for length in VALID_HSN_LENGTHS if length >= min_hsn_digits)
# VALID_HSN_LENGTHS = (4, 6, 8)  ->  (6, 8) at the default
```

So `6109` would have swapped `MandatoryError` for `"HSN/SAC Code should be 6 or 8 digits long"`. `61091000` is the same heading (knitted cotton t-shirts) at eight digits, and stays valid whatever a site raises `min_hsn_digits` to.

## Verified end to end

On a reinstalled `commera-fresh.localhost` with india_compliance installed (`validate_hsn_code = 1`, `min_hsn_digits = 6`, 18,687 GST HSN Code rows):

```
$ install_summer_demo(currency="INR")
Done: 34307 events, 13554 sessions, 311 orders, 15 prior-history orders, 15 draft quotations
✅ Summer demo seeded in INR
SEEDER_RESULT: OK

Items: 81 | without gst_hsn_code: 0
   '61091000' -> 81 items
   template KNIT-CARDIGAN                hsn=61091000
   variant  KNIT-CARDIGAN-PIN-S          hsn=61091000
```

All 81 items — 9 templates and 72 variants — carry the code; none missing. The variants needed it separately, since `save_item_variants` builds each size as its own `Item` dict rather than through `make_variant`, so it inherits nothing from the template.

The `has_real_orders()` guard behind the new dashboard button was exercised on the same site:

```
326 demo orders           -> has_real_orders() = False | button visible = True
+ 1 genuine order (session id None) -> has_real_orders() = True  | button visible = False
after rollback            -> False
```

That confirms the reason the guard counts seeded orders off the total instead of filtering them out: a real order's `custom_analytics_session_id` is `NULL`, which `not like` would have silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LwTi7ipvpFkSLHmuLhuEX